### PR TITLE
Update to 1.20.2 - with macros!!

### DIFF
--- a/camera-data/data/cam/functions/color/concat_hex.mcfunction
+++ b/camera-data/data/cam/functions/color/concat_hex.mcfunction
@@ -1,0 +1,4 @@
+# @macros
+# input: 
+# r1, r2, b1, b2, g1, g2
+$data modify storage cam:temp rgb set value '{"text":"","color":"#$(r1)$(r2)$(g1)$(g2)$(b1)$(b2)"}'

--- a/camera-data/data/cam/functions/color/get_color.mcfunction
+++ b/camera-data/data/cam/functions/color/get_color.mcfunction
@@ -1,60 +1,54 @@
-execute store result score r= cam.main run data get storage cam:main color.r
-execute store result score g= cam.main run data get storage cam:main color.g
-execute store result score b= cam.main run data get storage cam:main color.b
+execute store result score r= cam.main run data get storage cam:main color.r 10000
+execute store result score g= cam.main run data get storage cam:main color.g 10000
+execute store result score b= cam.main run data get storage cam:main color.b 10000
 
+scoreboard players operation r= cam.main /= #16 cam.main 
+scoreboard players operation g= cam.main /= #16 cam.main
+scoreboard players operation b= cam.main /= #16 cam.main
+
+# Red - 1-2 front digits - r1
 scoreboard players operation o= cam.main = r= cam.main
-execute if score o= cam.main matches 000..015 run function cam:capture/get_color/rgb/object_000
-execute if score o= cam.main matches 016..031 run function cam:capture/get_color/rgb/object_016
-execute if score o= cam.main matches 032..047 run function cam:capture/get_color/rgb/object_032
-execute if score o= cam.main matches 048..063 run function cam:capture/get_color/rgb/object_048
-execute if score o= cam.main matches 064..079 run function cam:capture/get_color/rgb/object_064
-execute if score o= cam.main matches 080..095 run function cam:capture/get_color/rgb/object_080
-execute if score o= cam.main matches 096..111 run function cam:capture/get_color/rgb/object_096
-execute if score o= cam.main matches 112..127 run function cam:capture/get_color/rgb/object_112
-execute if score o= cam.main matches 128..143 run function cam:capture/get_color/rgb/object_128
-execute if score o= cam.main matches 144..159 run function cam:capture/get_color/rgb/object_144
-execute if score o= cam.main matches 160..175 run function cam:capture/get_color/rgb/object_160
-execute if score o= cam.main matches 176..191 run function cam:capture/get_color/rgb/object_176
-execute if score o= cam.main matches 192..207 run function cam:capture/get_color/rgb/object_192
-execute if score o= cam.main matches 208..223 run function cam:capture/get_color/rgb/object_208
-execute if score o= cam.main matches 224..239 run function cam:capture/get_color/rgb/object_224
-execute if score o= cam.main matches 240..255 run function cam:capture/get_color/rgb/object_240
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "r1"
+function cam:color/get_hex_char with storage cam:temp {}
 
+# Red last digits
+scoreboard players operation o= cam.main = r= cam.main
+scoreboard players operation o= cam.main %= #10000 cam.main
+scoreboard players operation o= cam.main *= #16 cam.main
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "r2"
+function cam:color/get_hex_char with storage cam:temp {}
+
+# Green - 1-2 front digits - r1
 scoreboard players operation o= cam.main = g= cam.main
-execute if score o= cam.main matches 000..015 run function cam:capture/get_color/object_000
-execute if score o= cam.main matches 016..031 run function cam:capture/get_color/object_016
-execute if score o= cam.main matches 032..047 run function cam:capture/get_color/object_032
-execute if score o= cam.main matches 048..063 run function cam:capture/get_color/object_048
-execute if score o= cam.main matches 064..079 run function cam:capture/get_color/object_064
-execute if score o= cam.main matches 080..095 run function cam:capture/get_color/object_080
-execute if score o= cam.main matches 096..111 run function cam:capture/get_color/object_096
-execute if score o= cam.main matches 112..127 run function cam:capture/get_color/object_112
-execute if score o= cam.main matches 128..143 run function cam:capture/get_color/object_128
-execute if score o= cam.main matches 144..159 run function cam:capture/get_color/object_144
-execute if score o= cam.main matches 160..175 run function cam:capture/get_color/object_160
-execute if score o= cam.main matches 176..191 run function cam:capture/get_color/object_176
-execute if score o= cam.main matches 192..207 run function cam:capture/get_color/object_192
-execute if score o= cam.main matches 208..223 run function cam:capture/get_color/object_208
-execute if score o= cam.main matches 224..239 run function cam:capture/get_color/object_224
-execute if score o= cam.main matches 240..255 run function cam:capture/get_color/object_240
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "g1"
+function cam:color/get_hex_char with storage cam:temp {}
 
+# Green last digits
+scoreboard players operation o= cam.main = g= cam.main
+scoreboard players operation o= cam.main %= #10000 cam.main
+scoreboard players operation o= cam.main *= #16 cam.main
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "g2"
+function cam:color/get_hex_char with storage cam:temp {}
+
+# Blue - 1-2 front digits - r1
 scoreboard players operation o= cam.main = b= cam.main
-execute if score o= cam.main matches 000..015 run function cam:capture/get_color/object_000
-execute if score o= cam.main matches 016..031 run function cam:capture/get_color/object_016
-execute if score o= cam.main matches 032..047 run function cam:capture/get_color/object_032
-execute if score o= cam.main matches 048..063 run function cam:capture/get_color/object_048
-execute if score o= cam.main matches 064..079 run function cam:capture/get_color/object_064
-execute if score o= cam.main matches 080..095 run function cam:capture/get_color/object_080
-execute if score o= cam.main matches 096..111 run function cam:capture/get_color/object_096
-execute if score o= cam.main matches 112..127 run function cam:capture/get_color/object_112
-execute if score o= cam.main matches 128..143 run function cam:capture/get_color/object_128
-execute if score o= cam.main matches 144..159 run function cam:capture/get_color/object_144
-execute if score o= cam.main matches 160..175 run function cam:capture/get_color/object_160
-execute if score o= cam.main matches 176..191 run function cam:capture/get_color/object_176
-execute if score o= cam.main matches 192..207 run function cam:capture/get_color/object_192
-execute if score o= cam.main matches 208..223 run function cam:capture/get_color/object_208
-execute if score o= cam.main matches 224..239 run function cam:capture/get_color/object_224
-execute if score o= cam.main matches 240..255 run function cam:capture/get_color/object_240
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "b1"
+function cam:color/get_hex_char with storage cam:temp {}
+
+# Blue last digits
+scoreboard players operation o= cam.main = b= cam.main
+scoreboard players operation o= cam.main %= #10000 cam.main
+scoreboard players operation o= cam.main *= #16 cam.main
+execute store result storage cam:temp index int 0.0001 run scoreboard players get o= cam.main
+data modify storage cam:temp output set value "b2"
+function cam:color/get_hex_char with storage cam:temp {}
+
+function cam:color/concat_hex with storage cam:temp {}
 
 data modify storage cam:main line append from storage cam:temp rgb
 

--- a/camera-data/data/cam/functions/color/get_hex_char.mcfunction
+++ b/camera-data/data/cam/functions/color/get_hex_char.mcfunction
@@ -1,0 +1,4 @@
+# @macros
+# input:
+# index, output
+$data modify storage cam:temp $(output) set string storage cam:main hex_chars[$(index)]

--- a/camera-data/data/cam/functions/load.mcfunction
+++ b/camera-data/data/cam/functions/load.mcfunction
@@ -9,6 +9,8 @@ scoreboard players set #16 cam.main 16
 scoreboard players set #63 cam.main 63
 scoreboard players set #64 cam.main 64
 scoreboard players set #128 cam.main 128
+scoreboard players set #10000 cam.main 10000
+data modify storage cam:main hex_chars set value ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"]
 bossbar add cam:prog ""
 bossbar set cam:prog max 19612
 

--- a/camera-data/data/cam/predicates/capture_nearby.json
+++ b/camera-data/data/cam/predicates/capture_nearby.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": -1,"offsetZ": 1,  "predicate": {"block": {"tag": "cam:capture"}}},
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": 0, "offsetZ": 1,  "predicate": {"block": {"tag": "cam:capture"}}},

--- a/camera-data/data/cam/predicates/nearby.json
+++ b/camera-data/data/cam/predicates/nearby.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": -1,"offsetZ": 1,  "predicate": {"block": {"tag": "cam:blocks"}}},
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": 0, "offsetZ": 1,  "predicate": {"block": {"tag": "cam:blocks"}}},

--- a/camera-data/data/cam/predicates/water_nearby.json
+++ b/camera-data/data/cam/predicates/water_nearby.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": -1,"offsetZ": 1,  "predicate": {"block": {"blocks": ["minecraft:water"]}}},
 		{"condition": "minecraft:location_check", "offsetX": -1,"offsetY": 0, "offsetZ": 1,  "predicate": {"block": {"blocks": ["minecraft:water"]}}},

--- a/camera-data/data/cam/worldgen/biome/space.json
+++ b/camera-data/data/cam/worldgen/biome/space.json
@@ -1,7 +1,7 @@
 {
 	"temperature": 0.5,
 	"downfall": 0.5,
-	"precipitation": "rain",
+	"has_precipitation": false,
 	"effects": {
 		"sky_color": 7907327,
 		"fog_color": 12638463,


### PR DESCRIPTION
Updated pack to be used in 1.20.2 (thanks world gen issues...)
`command_storage_rgb.dat` is NOT REQUIRED after this update as the conversion is done on the fly using the new macros feature of 23w31a
![image](https://github.com/gibbsly/mc-camera/assets/37494321/bc7fdae6-25af-448c-ad14-849c1224f209)
